### PR TITLE
fix generate_short_message and add new spec

### DIFF
--- a/lib/rails_graylog/logger.rb
+++ b/lib/rails_graylog/logger.rb
@@ -66,7 +66,9 @@ module RailsGraylog
     end
 
     def generate_short_message(message, writing_object = nil)
-      writing_object.nil? ? "#{message.to_s[0...25]}..." : "#{writing_object.class.name}_#{writing_object.id}"
+      return message[:short_message] if message.is_a?(Hash) && message.key?(:short_message)
+      m = message.is_a?(Hash) && message.key?(:message) ? message[:message] : message
+      writing_object.nil? ? "#{m.to_s[0...25]}..." : "#{writing_object.class.name}_#{writing_object.id}"
     end
 
     def extract_hash_from_exception(exception)

--- a/lib/rails_graylog/logger.rb
+++ b/lib/rails_graylog/logger.rb
@@ -67,8 +67,9 @@ module RailsGraylog
 
     def generate_short_message(message, writing_object = nil)
       return message[:short_message] if message.is_a?(Hash) && message.key?(:short_message)
-      m = message.is_a?(Hash) && message.key?(:message) ? message[:message] : message
-      writing_object.nil? ? "#{m.to_s[0...25]}..." : "#{writing_object.class.name}_#{writing_object.id}"
+      m = message.is_a?(Hash) && message.key?(:message) ? message[:message] : message.to_s
+      m = "#{m[0...25]}..." if m.size > 25
+      writing_object.nil? ? m : "#{writing_object.class.name}_#{writing_object.id}"
     end
 
     def extract_hash_from_exception(exception)

--- a/spec/rails_graylog/logger_spec.rb
+++ b/spec/rails_graylog/logger_spec.rb
@@ -65,5 +65,19 @@ describe RailsGraylog::Logger do
         subject.info(data_hash)
       end
     end
+
+    context 'when logging hash data with message and an additional field' do
+      let(:message_with_field) { { message: Faker::Lorem.sentence, other_field: 'custom value' }}
+
+      it 'calls the graylog notifier with the additional field' do
+        expect(notifier).to receive(:notify!).with(
+          message: message_with_field[:message], full_message: message_with_field[:message],
+          short_message: "#{message_with_field[:message].to_s[0...25]}...",
+          other_field: 'custom value',
+          severity: 'INFO')
+
+        subject.info(message_with_field)
+      end
+    end
   end
 end


### PR DESCRIPTION
Changes made for https://creativegroupdev.atlassian.net/browse/REC-591.

Allows sending additional fields when using a hash for the message data.

